### PR TITLE
Update to react/http 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
         }
     ],
     "require": {
-        "react/http": "^0.8.0",
+        "react/http": "^1.0",
         "voryx/thruway": "^0.5.0",
-        "voryx/websocketmiddleware": "^1.0.3"
+        "voryx/websocketmiddleware": "^1.1"
     },
     "autoload": {
         "psr-4": {

--- a/example/bringYourOwnRouter.php
+++ b/example/bringYourOwnRouter.php
@@ -28,7 +28,7 @@ $router->start(false);
 
 $thruway = new Middleware(['/thruway'], $loop, $router);
 
-$server = new Server($thruway);
+$server = new Server($loop, $thruway);
 $server->listen(new \React\Socket\Server('tcp://127.0.0.1:9001', $loop));
 
 $loop->run();

--- a/example/simpleRouter.php
+++ b/example/simpleRouter.php
@@ -10,7 +10,7 @@ $loop = Factory::create();
 
 $thruway = new Middleware(['/thruway'], $loop);
 
-$server = new Server($thruway);
+$server = new Server($loop, $thruway);
 $server->listen(new \React\Socket\Server('tcp://127.0.0.1:9001', $loop));
 
 $loop->run();

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -5,7 +5,7 @@ namespace Thruway;
 use function GuzzleHttp\Psr7\parse_query;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\LoopInterface;
-use React\Http\Response;
+use React\Http\Message\Response;
 use Thruway\Event\ConnectionCloseEvent;
 use Thruway\Event\ConnectionOpenEvent;
 use Thruway\Event\RouterStartEvent;
@@ -128,7 +128,7 @@ final class Middleware implements RouterTransportProviderInterface
         }
     }
 
-    public function __invoke(ServerRequestInterface $request, callable $next)
+    public function __invoke(ServerRequestInterface $request, callable $next = null)
     {
         return $this->webSocketMiddleware->__invoke($request, $next);
     }


### PR DESCRIPTION
This PR depends on https://github.com/voryx/WebSocketMiddleware/pull/6 to be tagged and released and assumes that both packages need a major version bump due to react/http version targeting as a result in backwards-incompatible code changes.